### PR TITLE
Correct release version and zip file name

### DIFF
--- a/gefyra/src/__tests__/install.tests.ts
+++ b/gefyra/src/__tests__/install.tests.ts
@@ -2,8 +2,15 @@ import { unlinkSync } from 'fs';
 import { join } from 'path';
 import { InstallError } from '../errors';
 import { install, checkInstalled, binaryPath } from '../install';
+import { type } from 'os';
 
-const zipName = 'gefyra-0.3.2-linux-amd64.zip';
+const zipNameMap = {
+  'Linux': 'gefyra-0.13.4-linux-amd64.zip',
+  'Darwin': 'gefyra-0.13.4-darwin-universal.zip',
+  'Windows_NT': 'gefyra-0.13.4-windows-x86_64.zip'
+};
+const platform = type();
+const zipName = zipNameMap[platform];
 const outputDir = join(__dirname, '..');
 const zipPath = join(outputDir, zipName);
 

--- a/gefyra/src/install.ts
+++ b/gefyra/src/install.ts
@@ -43,7 +43,7 @@ const getPlatform = () => {
 };
 
 function filterRelease(release: any): boolean {
-  return release.name === '0.3.4';
+  return release.name === '0.3.5';
 }
 
 function filterAsset(asset: any) {


### PR DESCRIPTION
## What

I corrected release version from `0.3.4` to `0.3.5` in `filterRelease` function.
also, in the `_tests_/install.tests`, `zipName` will be dynamic according to current platform.

## Why

release version was pointing old one instead of latest.
in the `install.tests`, `zipName` was static one for `linux` platform, that needs to be dynamic for current platform.